### PR TITLE
refactor: re-implement map type

### DIFF
--- a/y-octo/benches/map_ops_benchmarks.rs
+++ b/y-octo/benches/map_ops_benchmarks.rs
@@ -16,7 +16,7 @@ fn operations(c: &mut Criterion) {
             let doc = Doc::default();
             let mut map = doc.get_or_create_map("test").unwrap();
             for (idx, key) in base_text.iter().enumerate() {
-                map.insert(key, idx).unwrap();
+                map.insert(key.to_string(), idx).unwrap();
             }
         });
     });
@@ -49,7 +49,7 @@ fn operations(c: &mut Criterion) {
         let doc = Doc::default();
         let mut map = doc.get_or_create_map("test").unwrap();
         for (idx, key) in base_text.iter().enumerate() {
-            map.insert(key, idx).unwrap();
+            map.insert(key.to_string(), idx).unwrap();
         }
 
         b.iter(|| {
@@ -93,7 +93,7 @@ fn operations(c: &mut Criterion) {
             let doc = Doc::default();
             let mut map = doc.get_or_create_map("test").unwrap();
             for (idx, key) in base_text.iter().enumerate() {
-                map.insert(key, idx).unwrap();
+                map.insert(key.to_string(), idx).unwrap();
             }
             for key in &base_text {
                 map.remove(key);

--- a/y-octo/bin/memory_leak_test.rs
+++ b/y-octo/bin/memory_leak_test.rs
@@ -63,7 +63,7 @@ fn run_map_test() {
         let doc = Doc::default();
         let mut map = doc.get_or_create_map("test").unwrap();
         for (idx, key) in base_text.iter().enumerate() {
-            map.insert(key, idx).unwrap();
+            map.insert(key.to_string(), idx).unwrap();
         }
     }
 }

--- a/y-octo/src/doc/codec/refs.rs
+++ b/y-octo/src/doc/codec/refs.rs
@@ -1,5 +1,3 @@
-use sync::Arc;
-
 use super::*;
 
 // make fields Copy + Clone without much effort
@@ -81,7 +79,7 @@ impl Node {
             _ => {
                 let item = Somr::new(Item::read(decoder, id, info, first_5_bit)?);
 
-                if let Content::Type(ty) = item.get().unwrap().content.as_ref() {
+                if let Content::Type(ty) = &item.get().unwrap().content {
                     if let Some(mut ty) = ty.ty_mut() {
                         ty.item = item.clone();
                     }
@@ -271,7 +269,7 @@ impl Node {
                     return false;
                 }
 
-                match (Arc::make_mut(&mut litem.content), Arc::make_mut(&mut ritem.content)) {
+                match (&mut litem.content, &mut ritem.content) {
                     (Content::Deleted(l), Content::Deleted(r)) => {
                         *l += *r;
                     }

--- a/y-octo/src/doc/codec/utils/items.rs
+++ b/y-octo/src/doc/codec/utils/items.rs
@@ -1,5 +1,4 @@
 use super::{item::item_flags, *};
-use crate::sync::Arc;
 
 pub(crate) struct ItemBuilder {
     item: Item,
@@ -54,7 +53,7 @@ impl ItemBuilder {
     }
 
     pub fn content(mut self, content: Content) -> ItemBuilder {
-        self.item.content = Arc::new(content);
+        self.item.content = content;
         self
     }
 
@@ -92,7 +91,7 @@ mod tests {
             assert_eq!(item.origin_right_id, Some(Id::new(4, 5)));
             assert!(matches!(item.parent, Some(Parent::String(text)) if text == "test"));
             assert_eq!(item.parent_sub, None);
-            assert_eq!(item.content, Arc::new(Content::Any(vec![Any::String("Hello".into())])));
+            assert_eq!(item.content, Content::Any(vec![Any::String("Hello".into())]));
         });
     }
 }

--- a/y-octo/src/doc/document.rs
+++ b/y-octo/src/doc/document.rs
@@ -416,7 +416,7 @@ mod tests {
                 let doc = Doc::new();
 
                 let mut map = doc.get_or_create_map("abc").unwrap();
-                map.insert("a", 1).unwrap();
+                map.insert("a".to_string(), 1).unwrap();
                 let binary = doc.encode_update_v1().unwrap();
 
                 let doc_new = Doc::new();

--- a/y-octo/src/doc/history.rs
+++ b/y-octo/src/doc/history.rs
@@ -119,9 +119,7 @@ impl StoreHistory {
             histories.push(History {
                 id: item.id.to_string(),
                 parent: Self::parse_path(item, &parents),
-                content: Value::try_from(item.content.as_ref())
-                    .map(|v| v.to_string())
-                    .unwrap_or("unknown".to_owned()),
+                content: Value::from(&item.content).to_string(),
             })
         }
 
@@ -243,8 +241,8 @@ mod test {
             let doc = Doc::default();
             let mut map = doc.get_or_create_map("map").unwrap();
             let mut sub_map = doc.create_map().unwrap();
-            map.insert("sub_map", sub_map.clone()).unwrap();
-            sub_map.insert("key", "value").unwrap();
+            map.insert("sub_map".to_string(), sub_map.clone()).unwrap();
+            sub_map.insert("key".to_string(), "value").unwrap();
 
             assert_eq!(doc.clients()[0], doc.client());
         });
@@ -256,8 +254,8 @@ mod test {
             let doc = Doc::default();
             let mut map = doc.get_or_create_map("map").unwrap();
             let mut sub_map = doc.create_map().unwrap();
-            map.insert("sub_map", sub_map.clone()).unwrap();
-            sub_map.insert("key", "value").unwrap();
+            map.insert("sub_map".to_string(), sub_map.clone()).unwrap();
+            sub_map.insert("key".to_string(), "value").unwrap();
 
             let history = StoreHistory::new(&doc.store);
 

--- a/y-octo/src/doc/publisher.rs
+++ b/y-octo/src/doc/publisher.rs
@@ -201,12 +201,12 @@ mod tests {
             });
 
             let mut map = doc.get_or_create_map("test").unwrap();
-            map.insert("key1", "val1").unwrap();
+            map.insert("key1".to_string(), "val1").unwrap();
 
             sleep(Duration::from_secs(1));
 
-            map.insert("key2", "val2").unwrap();
-            map.insert("key3", "val3").unwrap();
+            map.insert("key2".to_string(), "val2").unwrap();
+            map.insert("key3".to_string(), "val3").unwrap();
             sleep(Duration::from_secs(1));
 
             let mut array = doc.get_or_create_array("array").unwrap();

--- a/y-octo/src/doc/types/array.rs
+++ b/y-octo/src/doc/types/array.rs
@@ -4,16 +4,16 @@ impl_type!(Array);
 
 impl ListType for Array {}
 
-pub struct ArrayIter(ListIterator);
+pub struct ArrayIter<'a>(ListIterator<'a>);
 
-impl Iterator for ArrayIter {
+impl Iterator for ArrayIter<'_> {
     type Item = Value;
 
     fn next(&mut self) -> Option<Self::Item> {
         for item in self.0.by_ref() {
             if let Some(item) = item.get() {
                 if item.countable() {
-                    return Some(item.content.as_ref().try_into().unwrap());
+                    return Some(Value::try_from(&item.content).unwrap());
                 }
             }
         }
@@ -39,9 +39,9 @@ impl Array {
         debug_assert!(offset == 0);
         if let Some(item) = item.get() {
             // TODO: rewrite to content.read(&mut [Any])
-            return match item.content.as_ref() {
+            return match &item.content {
                 Content::Any(any) => return any.first().map(|any| Value::Any(any.clone())),
-                _ => item.content.as_ref().try_into().map_or_else(|_| None, Some),
+                _ => Value::try_from(&item.content).map_or_else(|_| None, Some),
             };
         }
 
@@ -83,8 +83,6 @@ impl serde::Serialize for Array {
 
 #[cfg(test)]
 mod tests {
-    use yrs::{Array, Options, Text, Transact};
-
     use super::*;
 
     #[test]
@@ -108,6 +106,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)]
     fn test_ytext_equal() {
+        use yrs::{Options, Text, Transact};
         let options = DocOptions::default();
         let yrs_options = Options::default();
 
@@ -166,6 +165,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)]
     fn test_yrs_array_decode() {
+        use yrs::{Array, Transact};
         let update = {
             let doc = yrs::Doc::new();
             let array = doc.get_or_insert_array("abc");

--- a/y-octo/src/doc/types/list/iterator.rs
+++ b/y-octo/src/doc/types/list/iterator.rs
@@ -1,10 +1,11 @@
 use super::*;
 
-pub(crate) struct ListIterator {
+pub(crate) struct ListIterator<'a> {
+    pub(super) _lock: RwLockReadGuard<'a, YType>,
     pub(super) cur: Somr<Item>,
 }
 
-impl Iterator for ListIterator {
+impl Iterator for ListIterator<'_> {
     type Item = Somr<Item>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -18,11 +19,5 @@ impl Iterator for ListIterator {
         }
 
         None
-    }
-}
-
-impl ListIterator {
-    pub fn new(start: Somr<Item>) -> Self {
-        Self { cur: start }
     }
 }

--- a/y-octo/src/doc/types/list/mod.rs
+++ b/y-octo/src/doc/types/list/mod.rs
@@ -62,7 +62,10 @@ pub(crate) trait ListType: AsInner<Inner = YTypeRef> {
 
     fn iter_item(&self) -> ListIterator {
         let inner = self.as_inner().ty().unwrap();
-        ListIterator::new(inner.start.clone())
+        ListIterator {
+            cur: inner.start.clone(),
+            _lock: inner,
+        }
     }
 
     fn find_pos(&self, inner: &YType, index: u64) -> Option<ItemPosition> {

--- a/y-octo/src/doc/types/mod.rs
+++ b/y-octo/src/doc/types/mod.rs
@@ -2,6 +2,8 @@ mod array;
 mod list;
 mod map;
 mod text;
+mod value;
+mod xml;
 
 use std::{
     collections::{hash_map::Entry, HashMap},
@@ -12,10 +14,12 @@ pub use array::*;
 use list::*;
 pub use map::*;
 pub use text::*;
+pub use value::*;
+pub use xml::*;
 
 use super::{
     store::{StoreRef, WeakStoreRef},
-    Node, *,
+    *,
 };
 use crate::{
     sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard},
@@ -363,158 +367,3 @@ impl_variants!({
     XMLText: 6
     // Doc: 9?
 });
-
-// TODO: move to separated impl files.
-impl_type!(XMLElement);
-impl_type!(XMLFragment);
-impl_type!(XMLText);
-impl_type!(XMLHook);
-
-#[derive(Debug, PartialEq)]
-pub enum Value {
-    Any(Any),
-    Doc(Doc),
-    Array(Array),
-    Map(Map),
-    Text(Text),
-    XMLElement(XMLElement),
-    XMLFragment(XMLFragment),
-    XMLHook(XMLHook),
-    XMLText(XMLText),
-}
-
-impl Value {
-    pub fn to_any(&self) -> Option<Any> {
-        match self {
-            Value::Any(any) => Some(any.clone()),
-            _ => None,
-        }
-    }
-
-    pub fn to_array(&self) -> Option<Array> {
-        match self {
-            Value::Array(array) => Some(array.clone()),
-            _ => None,
-        }
-    }
-
-    pub fn to_map(&self) -> Option<Map> {
-        match self {
-            Value::Map(map) => Some(map.clone()),
-            _ => None,
-        }
-    }
-
-    pub fn to_text(&self) -> Option<Text> {
-        match self {
-            Value::Text(text) => Some(text.clone()),
-            _ => None,
-        }
-    }
-
-    pub fn from_vec<T: Into<Any>>(el: Vec<T>) -> Self {
-        Value::Any(Any::Array(el.into_iter().map(|item| item.into()).collect::<Vec<_>>()))
-    }
-}
-
-impl TryFrom<&Content> for Value {
-    type Error = JwstCodecError;
-    fn try_from(value: &Content) -> Result<Self, Self::Error> {
-        Ok(match value {
-            Content::Any(any) => Value::Any(if any.len() == 1 {
-                any[0].clone()
-            } else {
-                Any::Array(any.clone())
-            }),
-            Content::String(s) => Value::Any(Any::String(s.clone())),
-            Content::Json(json) => Value::Any(Any::Array(
-                json.iter()
-                    .map(|item| {
-                        if let Some(s) = item {
-                            Any::String(s.clone())
-                        } else {
-                            Any::Undefined
-                        }
-                    })
-                    .collect::<Vec<_>>(),
-            )),
-            Content::Binary(buf) => Value::Any(Any::Binary(buf.clone())),
-            Content::Embed(v) => Value::Any(v.clone()),
-            Content::Type(ty) => match ty.ty().unwrap().kind {
-                YTypeKind::Array => Value::Array(Array::from_unchecked(ty.clone())),
-                YTypeKind::Map => Value::Map(Map::from_unchecked(ty.clone())),
-                YTypeKind::Text => Value::Text(Text::from_unchecked(ty.clone())),
-                YTypeKind::XMLElement => Value::XMLElement(XMLElement::from_unchecked(ty.clone())),
-                YTypeKind::XMLFragment => Value::XMLFragment(XMLFragment::from_unchecked(ty.clone())),
-                YTypeKind::XMLHook => Value::XMLHook(XMLHook::from_unchecked(ty.clone())),
-                YTypeKind::XMLText => Value::XMLText(XMLText::from_unchecked(ty.clone())),
-                // actually unreachable
-                YTypeKind::Unknown => return Err(JwstCodecError::TypeCastError("unknown")),
-            },
-            Content::Doc { guid: _, opts } => Value::Doc(DocOptions::try_from(opts.clone())?.build()),
-            Content::Format { .. } => return Err(JwstCodecError::TypeCastError("unimplemented: Format")),
-            Content::Deleted(_) => return Err(JwstCodecError::TypeCastError("unimplemented: Deleted")),
-        })
-    }
-}
-
-impl From<Value> for Content {
-    fn from(value: Value) -> Self {
-        match value {
-            Value::Any(any) => Content::from(any),
-            Value::Doc(doc) => Content::Doc {
-                guid: doc.guid().to_owned(),
-                opts: Any::from(doc.options().clone()),
-            },
-            Value::Array(v) => Content::Type(v.0),
-            Value::Map(v) => Content::Type(v.0),
-            Value::Text(v) => Content::Type(v.0),
-            Value::XMLElement(v) => Content::Type(v.0),
-            Value::XMLFragment(v) => Content::Type(v.0),
-            Value::XMLHook(v) => Content::Type(v.0),
-            Value::XMLText(v) => Content::Type(v.0),
-        }
-    }
-}
-
-impl<T: Into<Any>> From<T> for Value {
-    fn from(value: T) -> Self {
-        Value::Any(value.into())
-    }
-}
-
-impl From<Doc> for Value {
-    fn from(value: Doc) -> Self {
-        Value::Doc(value)
-    }
-}
-
-impl ToString for Value {
-    fn to_string(&self) -> String {
-        match self {
-            Value::Any(any) => any.to_string(),
-            Value::Text(text) => text.to_string(),
-            _ => String::default(),
-        }
-    }
-}
-
-impl serde::Serialize for Value {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        match self {
-            Self::Any(any) => any.serialize(serializer),
-            Self::Array(array) => array.serialize(serializer),
-            Self::Map(map) => map.serialize(serializer),
-            Self::Text(text) => text.serialize(serializer),
-            // Self::XMLElement(xml_element) => xml_element.serialize(serializer),
-            // Self::XMLFragment(xml_fragment) => xml_fragment.serialize(serializer),
-            // Self::XMLHook(xml_hook) => xml_hook.serialize(serializer),
-            // Self::XMLText(xml_text) => xml_text.serialize(serializer),
-            // Self::Doc(doc) => doc.serialize(serializer),
-            _ => serializer.serialize_none(),
-        }
-    }
-}

--- a/y-octo/src/doc/types/text.rs
+++ b/y-octo/src/doc/types/text.rs
@@ -32,7 +32,7 @@ impl ToString for Text {
         let mut ret = String::with_capacity(self.len() as usize);
 
         self.iter_item().fold(&mut ret, |ret, item| {
-            if let Content::String(str) = item.get().unwrap().content.as_ref() {
+            if let Content::String(str) = &item.get().unwrap().content {
                 ret.push_str(str);
             }
 

--- a/y-octo/src/doc/types/value.rs
+++ b/y-octo/src/doc/types/value.rs
@@ -1,0 +1,154 @@
+use super::*;
+
+#[derive(Debug, PartialEq)]
+pub enum Value {
+    Any(Any),
+    Doc(Doc),
+    Array(Array),
+    Map(Map),
+    Text(Text),
+    XMLElement(XMLElement),
+    XMLFragment(XMLFragment),
+    XMLHook(XMLHook),
+    XMLText(XMLText),
+}
+
+impl Value {
+    pub fn to_any(&self) -> Option<Any> {
+        match self {
+            Value::Any(any) => Some(any.clone()),
+            _ => None,
+        }
+    }
+
+    pub fn to_array(&self) -> Option<Array> {
+        match self {
+            Value::Array(array) => Some(array.clone()),
+            _ => None,
+        }
+    }
+
+    pub fn to_map(&self) -> Option<Map> {
+        match self {
+            Value::Map(map) => Some(map.clone()),
+            _ => None,
+        }
+    }
+
+    pub fn to_text(&self) -> Option<Text> {
+        match self {
+            Value::Text(text) => Some(text.clone()),
+            _ => None,
+        }
+    }
+
+    pub fn from_vec<T: Into<Any>>(el: Vec<T>) -> Self {
+        Value::Any(Any::Array(el.into_iter().map(|item| item.into()).collect::<Vec<_>>()))
+    }
+}
+
+impl From<&Content> for Value {
+    fn from(value: &Content) -> Value {
+        match value {
+            Content::Any(any) => Value::Any(if any.len() == 1 {
+                any[0].clone()
+            } else {
+                Any::Array(any.clone())
+            }),
+            Content::String(s) => Value::Any(Any::String(s.clone())),
+            Content::Json(json) => Value::Any(Any::Array(
+                json.iter()
+                    .map(|item| {
+                        if let Some(s) = item {
+                            Any::String(s.clone())
+                        } else {
+                            Any::Undefined
+                        }
+                    })
+                    .collect::<Vec<_>>(),
+            )),
+            Content::Binary(buf) => Value::Any(Any::Binary(buf.clone())),
+            Content::Embed(v) => Value::Any(v.clone()),
+            Content::Type(ty) => match ty.ty().unwrap().kind {
+                YTypeKind::Array => Value::Array(Array::from_unchecked(ty.clone())),
+                YTypeKind::Map => Value::Map(Map::from_unchecked(ty.clone())),
+                YTypeKind::Text => Value::Text(Text::from_unchecked(ty.clone())),
+                YTypeKind::XMLElement => Value::XMLElement(XMLElement::from_unchecked(ty.clone())),
+                YTypeKind::XMLFragment => Value::XMLFragment(XMLFragment::from_unchecked(ty.clone())),
+                YTypeKind::XMLHook => Value::XMLHook(XMLHook::from_unchecked(ty.clone())),
+                YTypeKind::XMLText => Value::XMLText(XMLText::from_unchecked(ty.clone())),
+                // actually unreachable
+                YTypeKind::Unknown => Value::Any(Any::Undefined),
+            },
+            Content::Doc { guid: _, opts } => Value::Doc(
+                DocOptions::try_from(opts.clone())
+                    .expect("Failed to parse doc options")
+                    .build(),
+            ),
+            Content::Format { .. } => unimplemented!(),
+            // actually unreachable
+            Content::Deleted(_) => Value::Any(Any::Undefined),
+        }
+    }
+}
+
+impl From<Value> for Content {
+    fn from(value: Value) -> Self {
+        match value {
+            Value::Any(any) => Content::from(any),
+            Value::Doc(doc) => Content::Doc {
+                guid: doc.guid().to_owned(),
+                opts: Any::from(doc.options().clone()),
+            },
+            Value::Array(v) => Content::Type(v.0),
+            Value::Map(v) => Content::Type(v.0),
+            Value::Text(v) => Content::Type(v.0),
+            Value::XMLElement(v) => Content::Type(v.0),
+            Value::XMLFragment(v) => Content::Type(v.0),
+            Value::XMLHook(v) => Content::Type(v.0),
+            Value::XMLText(v) => Content::Type(v.0),
+        }
+    }
+}
+
+impl<T: Into<Any>> From<T> for Value {
+    fn from(value: T) -> Self {
+        Value::Any(value.into())
+    }
+}
+
+impl From<Doc> for Value {
+    fn from(value: Doc) -> Self {
+        Value::Doc(value)
+    }
+}
+
+impl ToString for Value {
+    fn to_string(&self) -> String {
+        match self {
+            Value::Any(any) => any.to_string(),
+            Value::Text(text) => text.to_string(),
+            _ => String::default(),
+        }
+    }
+}
+
+impl serde::Serialize for Value {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Any(any) => any.serialize(serializer),
+            Self::Array(array) => array.serialize(serializer),
+            Self::Map(map) => map.serialize(serializer),
+            Self::Text(text) => text.serialize(serializer),
+            // Self::XMLElement(xml_element) => xml_element.serialize(serializer),
+            // Self::XMLFragment(xml_fragment) => xml_fragment.serialize(serializer),
+            // Self::XMLHook(xml_hook) => xml_hook.serialize(serializer),
+            // Self::XMLText(xml_text) => xml_text.serialize(serializer),
+            // Self::Doc(doc) => doc.serialize(serializer),
+            _ => serializer.serialize_none(),
+        }
+    }
+}

--- a/y-octo/src/doc/types/xml.rs
+++ b/y-octo/src/doc/types/xml.rs
@@ -1,0 +1,14 @@
+use super::list::ListType;
+use crate::impl_type;
+
+impl_type!(XMLElement);
+impl ListType for XMLElement {}
+
+impl_type!(XMLFragment);
+impl ListType for XMLFragment {}
+
+impl_type!(XMLText);
+impl ListType for XMLText {}
+
+impl_type!(XMLHook);
+impl ListType for XMLHook {}


### PR DESCRIPTION
#20 
- remove `Arc<Content>` on item
- make map iteration lazy
- standardize map user-seeing in/out type