### PR TITLE
docs: update AFFiNE Node.js server url

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Y-Octo also has interoperability and binary compatibility with [yjs]. Developers
 
 <a href="https://affine.pro"><img src="./assets/affine.svg" /></a>
 
-[AFFiNE](https://affine.pro) is using y-octo in production. There are [Electron](https://affine.pro/download) app and [Node.js server](https://github.com/toeverything/AFFiNE/tree/canary/packages/backend/storage) using y-octo in production.
+[AFFiNE](https://affine.pro) is using y-octo in production. There are [Electron](https://affine.pro/download) app and [Node.js server](https://github.com/toeverything/AFFiNE/tree/canary/packages/backend/native) using y-octo in production.
 
 <a href="https://www.mysc.app/"><img src="https://www.mysc.app/images/logo_blk.webp" width="120px" /></a>
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Y-Octo also has interoperability and binary compatibility with [yjs]. Developers
 
 <a href="https://affine.pro"><img src="./assets/affine.svg" /></a>
 
-[AFFiNE](https://affine.pro) is using y-octo in production. There are [Electron](https://affine.pro/download) app and [Node.js server](https://github.com/toeverything/AFFiNE/tree/master/packages/storage) using y-octo in production.
+[AFFiNE](https://affine.pro) is using y-octo in production. There are [Electron](https://affine.pro/download) app and [Node.js server](https://github.com/toeverything/AFFiNE/tree/canary/packages/backend/storage) using y-octo in production.
 
 <a href="https://www.mysc.app/"><img src="https://www.mysc.app/images/logo_blk.webp" width="120px" /></a>
 


### PR DESCRIPTION
The source code path of AFFiNE Node.js server was changed according to https://github.com/toeverything/AFFiNE/pull/4615/.