### PR TITLE
fix: avoid generating divergence-causing items in ListType::find_pos

### DIFF
--- a/y-octo/src/doc/types/list/mod.rs
+++ b/y-octo/src/doc/types/list/mod.rs
@@ -106,6 +106,7 @@ pub(crate) trait ListType: AsInner<Inner = YTypeRef> {
         // avoid the first item of the list being deleted
         while let Some(item) = pos.right.get() {
             if item.deleted() {
+                pos.left = pos.right.clone();
                 pos.right = item.right.clone();
                 continue;
             } else {

--- a/y-octo/src/doc/types/text.rs
+++ b/y-octo/src/doc/types/text.rs
@@ -522,6 +522,40 @@ mod tests {
 
     #[test]
     #[cfg(not(loom))]
+    fn test_insert_before_leading_tombstone_converges() {
+        fn sync(from: &Doc, to: &mut Doc) {
+            let sv = to.get_state_vector();
+            let update = from.encode_state_as_update_v1(&sv).unwrap();
+            to.apply_update_from_binary_v1(update).unwrap();
+        }
+
+        let c0 = Doc::with_client(0);
+        let mut t0 = c0.get_or_create_text("text").unwrap();
+        let mut c1 = Doc::with_client(1);
+        let mut t1 = c1.get_or_create_text("text").unwrap();
+        let mut c2 = Doc::with_client(2);
+        let mut t2 = c2.get_or_create_text("text").unwrap();
+
+        t0.insert(0, "a").unwrap();
+        sync(&c0, &mut c1);
+        t1.insert(1, "b").unwrap();
+
+        t0.insert(1, "c").unwrap();
+        t0.remove(0, 1).unwrap();
+
+        sync(&c0, &mut c2);
+        t2.insert(0, "d").unwrap();
+
+        sync(&c1, &mut c2);
+        sync(&c2, &mut c1);
+
+        let s1 = t1.to_string();
+        let s2 = t2.to_string();
+        assert_eq!(s1, s2, "c1 and c2 diverged: {s1:?} vs {s2:?}");
+    }
+
+    #[test]
+    #[cfg(not(loom))]
     fn test_parallel_insert_text() {
         let seed = rand::rng().random();
         let rand = ChaCha20Rng::seed_from_u64(seed);


### PR DESCRIPTION
This PR fixes a divergence bug in `ListType::find_pos`, reproduced at `4327355`:

```rust
fn sync(from: &Doc, to: &mut Doc) {
    let sv = to.get_state_vector();
    let update = from.encode_state_as_update_v1(&sv).unwrap();
    to.apply_update_from_binary_v1(update).unwrap();
}

let c0 = Doc::with_client(0);
let mut t0 = c0.get_or_create_text("text").unwrap();
let mut c1 = Doc::with_client(1);
let mut t1 = c1.get_or_create_text("text").unwrap();
let mut c2 = Doc::with_client(2);
let mut t2 = c2.get_or_create_text("text").unwrap();

t0.insert(0, "a").unwrap();
sync(&c0, &mut c1);
t1.insert(1, "b").unwrap();

t0.insert(1, "c").unwrap();
t0.remove(0, 1).unwrap();

sync(&c0, &mut c2);
t2.insert(0, "d").unwrap();

sync(&c1, &mut c2);
sync(&c2, &mut c1);

assert_eq!(t1.to_string(), t2.to_string());
// At 4327355, this panics:
//   assertion `left == right` failed: c1 and c2 diverged: "dcb" vs "bdc"
```

The root cause is in `find_pos`: when it skips a tombstone, it lets the new item's left and right origins point at non-adjacent elements. Here `"d"` is created with `origin_left_id = None` and `origin_right_id = "c"`, leaving the deleted `"a"` between the two origins. The Yjs integration algorithm does not converge in the presence of such an item; in fact, hand-crafting one makes Yrs and Yjs diverge in the same way.

This PR fixes it so that `origin_left_id` and `origin_right_id` are adjacent (the new item's left origin points to the leading tombstone `a`), matching the behavior of Yrs and Yjs. The snippet above is included as a regression test.

As an aside, this issue was found during formal verification of the Yjs algorithm ([iasakura/lean-yjs](https://github.com/iasakura/lean-yjs), [iasakura/cert-yjs](https://github.com/iasakura/cert-yjs)).
