### PR TITLE
fix: inherit deleted/keep flags when splitting an item

### DIFF
--- a/y-octo/src/doc/codec/item.rs
+++ b/y-octo/src/doc/codec/item.rs
@@ -219,11 +219,13 @@ impl Item {
             self.parent_sub.clone(),
         );
 
-        if left_item.deleted() {
+        if self.deleted() {
             left_item.flags.set_deleted();
+            right_item.flags.set_deleted();
         }
-        if left_item.keep() {
+        if self.keep() {
             left_item.flags.set_keep();
+            right_item.flags.set_keep();
         }
 
         Ok((left_item, right_item))
@@ -394,5 +396,45 @@ mod tests {
                 item_round_trip(item).unwrap();
             }
         }
+    }
+
+    #[test]
+    #[cfg(not(loom))]
+    fn split_at_inherits_flags() {
+        let build = || {
+            Item::new(
+                Id::new(1, 0),
+                Content::String("abc".into()),
+                Somr::none(),
+                Somr::none(),
+                Some(Parent::String("t".into())),
+                None,
+            )
+        };
+
+        let (left, right) = build().split_at(1).unwrap();
+        assert!(
+            !left.deleted() && !right.deleted(),
+            "a live item splits into live halves"
+        );
+        assert!(!left.keep() && !right.keep());
+
+        let deleted = build();
+        deleted.flags.set_deleted();
+        let (left, right) = deleted.split_at(1).unwrap();
+        assert!(left.deleted(), "left half of a deleted item stays deleted");
+        assert!(right.deleted(), "right half of a deleted item stays deleted");
+
+        let kept = build();
+        kept.flags.set_keep();
+        let (left, right) = kept.split_at(1).unwrap();
+        assert!(left.keep() && right.keep(), "both halves stay protected from gc");
+
+        // the halves own their flags, they do not share a flag word
+        let deleted = build();
+        deleted.flags.set_deleted();
+        let (left, right) = deleted.split_at(1).unwrap();
+        right.flags.clear_deleted();
+        assert!(left.deleted() && !right.deleted());
     }
 }

--- a/y-octo/src/doc/codec/refs.rs
+++ b/y-octo/src/doc/codec/refs.rs
@@ -175,7 +175,7 @@ impl Node {
             let right_id = Id::new(id.client, id.clock + offset);
             let (left_content, right_content) = item.content.split(offset)?;
 
-            let left_item = Somr::new(Item::new(
+            let left_item = Item::new(
                 id,
                 left_content,
                 // let caller connect left <-> node <-> right
@@ -183,9 +183,9 @@ impl Node {
                 Somr::none(),
                 item.parent.clone(),
                 item.parent_sub.clone(),
-            ));
+            );
 
-            let right_item = Somr::new(Item::new(
+            let right_item = Item::new(
                 right_id,
                 right_content,
                 // let caller connect left <-> node <-> right
@@ -193,9 +193,18 @@ impl Node {
                 Somr::none(),
                 item.parent.clone(),
                 item.parent_sub.clone(),
-            ));
+            );
 
-            Ok((Self::Item(left_item), Self::Item(right_item)))
+            if item.deleted() {
+                left_item.flags.set_deleted();
+                right_item.flags.set_deleted();
+            }
+            if item.keep() {
+                left_item.flags.set_keep();
+                right_item.flags.set_keep();
+            }
+
+            Ok((Self::Item(Somr::new(left_item)), Self::Item(Somr::new(right_item))))
         } else {
             Err(JwstCodecError::ItemSplitNotSupport)
         }

--- a/y-octo/src/doc/types/text.rs
+++ b/y-octo/src/doc/types/text.rs
@@ -497,7 +497,7 @@ mod tests {
     use super::{TextAttributes, TextDeltaOp, TextInsert};
     #[cfg(not(loom))]
     use crate::sync::{Arc, AtomicUsize, Ordering};
-    use crate::{Any, Doc, loom_model, sync::thread};
+    use crate::{Any, Doc, DocOptions, loom_model, sync::thread};
 
     #[test]
     fn test_manipulate_text() {
@@ -552,6 +552,43 @@ mod tests {
         let s1 = t1.to_string();
         let s2 = t2.to_string();
         assert_eq!(s1, s2, "c1 and c2 diverged: {s1:?} vs {s2:?}");
+    }
+
+    #[test]
+    #[cfg(not(loom))]
+    fn test_split_of_tombstoned_item_keeps_both_halves_deleted() {
+        fn sync(from: &Doc, to: &mut Doc) {
+            let sv = to.get_state_vector();
+            let update = from.encode_state_as_update_v1(&sv).unwrap();
+            to.apply_update_from_binary_v1(update).unwrap();
+        }
+
+        for gc in [false, true] {
+            let mut c0 = DocOptions::new().with_client_id(0).auto_gc(gc).build();
+            let mut t0 = c0.get_or_create_text("text").unwrap();
+            let mut c1 = DocOptions::new().with_client_id(1).auto_gc(gc).build();
+            let mut t1 = c1.get_or_create_text("text").unwrap();
+
+            // one item covering clocks 0 to 2
+            t0.insert(0, "abc").unwrap();
+            sync(&c0, &mut c1);
+
+            // "z" is anchored at (0, 0) and (0, 1), pointing into that item
+            t1.insert(1, "z").unwrap();
+            t0.remove(0, 3).unwrap();
+
+            // repairing "z" splits the tombstoned item
+            sync(&c1, &mut c0);
+            sync(&c0, &mut c1);
+
+            assert_eq!(t0.to_string(), "z", "gc {gc}: c0 kept a resurrected half");
+            assert_eq!(t1.to_string(), "z", "gc {gc}: c1 kept a resurrected half");
+
+            // a document whose flags disagree with its delete set fails every later gc pass
+            t1.insert(0, "q").unwrap();
+            sync(&c1, &mut c0);
+            assert_eq!(t0.to_string(), "qz", "gc {gc}: c0 stopped accepting updates");
+        }
     }
 
     #[test]


### PR DESCRIPTION
`Item::split_at` now sets the deleted and keep flags on both halves from the original item, as yjs does in `Item.split`. `Node::split_at` had the same issue.

Before this change, splitting a tombstoned item brought the deleted content back, and with gc on every later `apply_update` failed with `JwstCodecError::Unexpected`. See `test_split_of_tombstoned_item_keeps_both_halves_deleted`.