### PR TITLE
fix: resolve conflict scan origins to the item that contains them

### DIFF
--- a/y-octo/src/doc/common/algorithm.rs
+++ b/y-octo/src/doc/common/algorithm.rs
@@ -48,6 +48,7 @@ pub(crate) fn find_conflict_left<T: Clone + Eq>(
     right: Option<T>,
     mut item: impl FnMut(&T) -> Option<ConflictItem>,
     mut next: impl FnMut(&T) -> Option<T>,
+    mut head_of: impl FnMut(Id) -> Option<Id>, // resolves an id to the head id of the item covering it
 ) -> Option<T> {
     let mut conflicting = HashSet::default();
     let mut before_origin = HashSet::default();
@@ -69,8 +70,10 @@ pub(crate) fn find_conflict_left<T: Clone + Eq>(
             } else if this.origin_right == candidate.origin_right {
                 break;
             }
-        } else if let Some(candidate_left) = candidate.origin_left {
-            if before_origin.contains(&candidate_left) && !conflicting.contains(&candidate_left) {
+        } else if let Some(candidate_left) = candidate.origin_left.and_then(&mut head_of)
+            && before_origin.contains(&candidate_left)
+        {
+            if !conflicting.contains(&candidate_left) {
                 left = Some(current.clone());
                 conflicting.clear();
             }
@@ -194,6 +197,7 @@ mod tests {
     #[derive(Clone, PartialEq, Eq, Debug)]
     struct ConflictNode {
         id: Id,
+        len: u64,
         origin_left: Option<Id>,
         origin_right: Option<Id>,
         right: Option<usize>,
@@ -219,6 +223,14 @@ mod tests {
                 })
             },
             |&index| nodes.get(index).and_then(|node| node.right),
+            |id| {
+                nodes
+                    .iter()
+                    .find(|node| {
+                        node.id.client == id.client && node.id.clock <= id.clock && id.clock < node.id.clock + node.len
+                    })
+                    .map(|node| node.id)
+            },
         )
     }
 
@@ -236,6 +248,7 @@ mod tests {
         let concurrent = |this_client: u64, other_client: u64| {
             let nodes = [ConflictNode {
                 id: Id::new(other_client, 0),
+                len: 1,
                 origin_left: None,
                 origin_right: None,
                 right: None,
@@ -249,6 +262,7 @@ mod tests {
         // insert before the candidate
         let nodes = [ConflictNode {
             id: Id::new(2, 0),
+            len: 1,
             origin_left: Some(Id::new(1, 0)),
             origin_right: Some(Id::new(1, 5)),
             right: None,
@@ -269,18 +283,21 @@ mod tests {
         let nodes = [
             ConflictNode {
                 id: Id::new(1, 0),
+                len: 1,
                 origin_left: Some(Id::new(8, 0)),
                 origin_right: None,
                 right: Some(1),
             },
             ConflictNode {
                 id: Id::new(2, 0),
+                len: 1,
                 origin_left: Some(Id::new(8, 0)),
                 origin_right: None,
                 right: Some(2),
             },
             ConflictNode {
                 id: Id::new(3, 0),
+                len: 1,
                 origin_left: Some(Id::new(1, 0)),
                 origin_right: None,
                 right: None,
@@ -294,6 +311,7 @@ mod tests {
         // a conflict chain that reaches the right neighbor keeps the current left
         let nodes = [ConflictNode {
             id: Id::new(2, 0),
+            len: 1,
             origin_left: Some(Id::new(1, 0)),
             origin_right: None,
             right: Some(1),
@@ -301,6 +319,34 @@ mod tests {
         assert_eq!(
             conflict_left(item(3, 0, Some(Id::new(9, 0)), None), None, Some(0), Some(1), &nodes),
             None
+        );
+    }
+
+    #[test]
+    fn conflict_left_resolves_origins_inside_multi_element_items() {
+        // the first item covers clocks 0 and 1, so the second one has
+        // origin_left (1, 1) while the first is recorded under (1, 0)
+        let nodes = [
+            ConflictNode {
+                id: Id::new(1, 0),
+                len: 2,
+                origin_left: None,
+                origin_right: None,
+                right: Some(1),
+            },
+            ConflictNode {
+                id: Id::new(2, 0),
+                len: 1,
+                origin_left: Some(Id::new(1, 1)),
+                origin_right: None,
+                right: None,
+            },
+        ];
+
+        // an item with no origins walks both and must end up after the second one
+        assert_eq!(
+            conflict_left(item(3, 0, None, None), None, Some(0), None, &nodes),
+            Some(1)
         );
     }
 }

--- a/y-octo/src/doc/read/resolve.rs
+++ b/y-octo/src/doc/read/resolve.rs
@@ -230,6 +230,7 @@ impl Builder {
                 right,
                 |id| Some(self.conflict_item(*id)),
                 |id| self.nodes[*id as usize].right(),
+                |id| self.locate(id).ok().map(|(_, node_id)| self.nodes[node_id as usize].id),
             );
         }
 

--- a/y-octo/src/doc/store.rs
+++ b/y-octo/src/doc/store.rs
@@ -536,6 +536,11 @@ impl DocStore {
                                 item.get()
                                     .and_then(|item| item.right.is_some().then(|| item.right.clone()))
                             },
+                            |id| {
+                                let nodes = self.items.get(&id.client)?;
+                                let index = Self::get_node_index(nodes, id.clock)?;
+                                nodes.get(index).map(|node| node.id())
+                            },
                         )
                         .unwrap_or_else(Somr::none);
                     }

--- a/y-octo/src/doc/types/text.rs
+++ b/y-octo/src/doc/types/text.rs
@@ -556,6 +556,45 @@ mod tests {
 
     #[test]
     #[cfg(not(loom))]
+    fn test_insert_beside_multi_element_item_converges() {
+        // client 0 inserts "ab" as one item, client 1 appends "c", client 2
+        // concurrently inserts "i" into an empty document. Every delivery
+        // order of the three updates has to give the same text.
+        let c0 = Doc::with_client(0);
+        let mut t0 = c0.get_or_create_text("text").unwrap();
+        t0.insert(0, "ab").unwrap();
+        let update_ab = c0.encode_update_v1().unwrap();
+        let sv_ab = c0.get_state_vector();
+
+        let mut c1 = Doc::with_client(1);
+        c1.apply_update_from_binary_v1(&update_ab).unwrap();
+        let mut t1 = c1.get_or_create_text("text").unwrap();
+        t1.insert(2, "c").unwrap();
+        let update_c = c1.encode_state_as_update_v1(&sv_ab).unwrap();
+
+        // client 2 has seen nothing, so its item carries no origins at all
+        let c2 = Doc::with_client(2);
+        let mut t2 = c2.get_or_create_text("text").unwrap();
+        t2.insert(0, "i").unwrap();
+        let update_i = c2.encode_update_v1().unwrap();
+
+        let orders = [
+            [&update_ab, &update_c, &update_i],
+            [&update_i, &update_ab, &update_c],
+            [&update_ab, &update_i, &update_c],
+        ];
+        for (index, order) in orders.iter().enumerate() {
+            let mut replica = Doc::with_client(10 + index as u64);
+            for update in *order {
+                replica.apply_update_from_binary_v1(update).unwrap();
+            }
+            let text = replica.get_or_create_text("text").unwrap().to_string();
+            assert_eq!(text, "abci", "delivery order {index} produced {text:?}");
+        }
+    }
+
+    #[test]
+    #[cfg(not(loom))]
     fn test_parallel_insert_text() {
         let seed = rand::rng().random();
         let rand = ChaCha20Rng::seed_from_u64(seed);


### PR DESCRIPTION
The set membership tests in `find_conflict_left` always failed when the id being looked up pointed to an element other than the first one of its item. As `test_insert_beside_multi_element_item_converges` shows, when an `origin_left_id` points to such an element the scan can return a wrong insertion point, and replicas diverge depending on the order the updates were applied in.

This PR looks up the id of the item holding that id before testing membership. The lookup needs the client's node list, which this function does not have, so it comes in as the `head_of` parameter: `DocStore` passes `get_node_index` and `read::resolve` passes `locate`.

The loop also stops in a different place than yjs and yrs: where both of them break out, this scan keeps walking. Although that does not look like it affects convergence, I changed it to match yjs and yrs, as it only adds iterations with no benefit.
